### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,14 +12,14 @@ HologramSIMCOM	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin	            KEYWORD2
-debug               KEYWORD2
-cellService         KEYWORD2
-cellStrength	    KEYWORD2
-send	            KEYWORD2
-sendSMS     	    KEYWORD2
+begin	KEYWORD2
+debug	KEYWORD2
+cellService	KEYWORD2
+cellStrength	KEYWORD2
+send	KEYWORD2
+sendSMS	KEYWORD2
 availableMessage	KEYWORD2
-readMessage	        KEYWORD2
+readMessage	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords